### PR TITLE
From etherpoker

### DIFF
--- a/ethjsonrpc/client.py
+++ b/ethjsonrpc/client.py
@@ -84,11 +84,7 @@ class EthJsonRpc(object):
         types = signature[signature.find('(') + 1: signature.find(')')].split(',')
         encoded_params = encode_abi(types, param_values)
         return utils.zpad(utils.encode_int(prefix), 4) + encoded_params
-
-#    def _install_contract(self, language, contract_code, value=0, from_address=None, gas=None, gas_price=None):
-#        byte_code = self.compilers[language](contract_code)
-#        return self.eth_sendTransaction(data=byte_code, value=value, from_address=from_address, gas=gas, gas_price=gas_price)
-        
+       
     def _install_contract(self, language, contract_code, value=0, from_address=None, 
                           gas=None, gas_price=None, ctor_sig=None, ctor_params=None, byte_data=None):
         '''
@@ -106,8 +102,7 @@ class EthJsonRpc(object):
             byte_data = byte_data + encoded_params        
         
         return self.eth_sendTransaction(data=byte_data, value=value, from_address=from_address, gas=gas, gas_price=gas_price)        
-                
-        
+                        
     def install_solidity_contract(self, contract_code, value=0, from_address=None, gas=None, gas_price=None):
         '''
         Installs a solidity contract into ethereum node
@@ -126,29 +121,8 @@ class EthJsonRpc(object):
         '''
         return self._install_contract('lll', contract_code, value, from_address, gas, gas_price)
 
-#     def contract_instant_call(self, to_address, function_signature, function_parameters=None, result_types=None, default_block=BLOCK_TAG_LATEST):
-#         '''
-#         This method makes a instant call on a contract function without the need to have the contract source code.
-#         Examples of function_signature in solidity:
-#             mult(uint x, uint y) => sig: mult(uint256,uint256) (all uint should be transformed to uint256)
-#             setAddress(address entity_address) =>  sig:setAddress(address)
-#             doSomething() => sig: doSomething() (functions with no parameters must end with the '()')
-#         In serpent, all functions parameter signatures are int256. Example:
-#             setXYZ(x, y, z) => sig: setXYZ(int256,int256,int256)
-#         '''
-#         data = self._encode_function(function_signature, function_parameters)
-#         params = [
-#             {
-#                 'to': to_address,
-#                 'data': '0x{0}'.format(data.encode('hex'))
-#             },
-#             default_block
-#         ]
-#         response = self._call('eth_call', params)
-#         return decode_abi(result_types, response[2:].decode('hex'))
-
     def contract_instant_call(self, to_address, function_signature, function_parameters=None, result_types=None, default_block=BLOCK_TAG_LATEST, from_address=None):
-        """
+        '''
         This method makes a instant call on a contract function without the need to have the contract source code.
         Examples of function_signature in solidity:
             mult(uint x, uint y) => sig: mult(uint256,uint256) (all uint should be transformed to uint256)
@@ -156,7 +130,7 @@ class EthJsonRpc(object):
             doSomething() => sig: doSomething() (functions with no parameters must end with the '()')
         In serpent, all functions parameter signatures are int256. Example:
             setXYZ(x, y, z) => sig: setXYZ(int256,int256,int256)
-        """
+        '''
         data = self._encode_function(function_signature, function_parameters)
         params = [
             {


### PR DESCRIPTION
install_contract():
- added "ctor_sig=None, ctor_params=None" 
if these are specified then the contract constructor is called with the given parameters
- added ",byte_data=None" -  If `byte_data` is specified then it is used as-is and no attempt is made to compile the contract code.

contract_instant_call:
- added "from_address=None" - without this, msg.sender in contract code accessed via eth_call() is ill-defined