### PR TITLE
Use a default id value of 1 to ensure smooth interactions with pyethapp's JSON RPC interface

### DIFF
--- a/ethjsonrpc/client.py
+++ b/ethjsonrpc/client.py
@@ -26,7 +26,7 @@ class EthJsonRpc(object):
         self.port = port
         self.tls = tls
 
-    def _call(self, method, params=None, _id=0):
+    def _call(self, method, params=None, _id=1):
 
         params = params or []
         data = {


### PR DESCRIPTION
Hi 

I ran across this https://github.com/mbr/tinyrpc/issues/27#issuecomment-218324935 earlier today.  
It seems like the root cause is indeed in the tinyrpc code since it looks like there's no requirement that an `id` not be `0` http://www.jsonrpc.org/specification#request_object .   However, I thought I'd offer up this small adjustment in case `1` is a better default value for `ethjsonrpc`.  Without this adjustment, folks won't be able to use ethjsonrpc with pyethapp until https://github.com/mbr/tinyrpc/issues/27 is resolved (and updated in pyethapp).  

Thanks,

Brian