### PR TITLE
update eth_sendRawTransaction to construct params according to https://github.com/ethereum/wiki/wiki/JSON-RPC

### DIFF
--- a/ethjsonrpc/client.py
+++ b/ethjsonrpc/client.py
@@ -338,7 +338,7 @@ class EthJsonRpc(object):
 
         NEEDS TESTING
         '''
-        return self._call('eth_sendRawTransaction', [{'data': data}])
+        return self._call('eth_sendRawTransaction', [data])
 
     def eth_call(self, to_address, from_address=None, gas=None, gas_price=None, value=None, data=None,
                  default_block=BLOCK_TAG_LATEST):


### PR DESCRIPTION
Hi,

I ran across a problem using the JSON RPC method `eth_sendRawTransaction` with ethjsonrpc.
In the https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sendrawtransaction documentation, it shows `"params":[{see above}]` in the example, but that seems to really mean `[{data}]`
where `data` is 
```
"0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"
```
in the guide.

That also seems to be how other clients implement it like
https://github.com/ethereum/web3.js/blob/master/lib/web3/methods/eth.js#L191
With this slight adjustment in place, I'm able to use the `EthJsonRpc.eth_sendRawTransaction` method successfully.

Thanks,

Brian