### PR TITLE
Fix eth_estimateGas to return an int

### DIFF
--- a/ethjsonrpc/client.py
+++ b/ethjsonrpc/client.py
@@ -387,7 +387,7 @@ class EthJsonRpc(object):
             obj['value'] = value
         if data is not None:
             obj['data'] = data
-        return self._call('eth_estimateGas', [obj, default_block])
+        return hex_to_dec(self._call('eth_estimateGas', [obj, default_block]))
 
     def eth_getBlockByHash(self, block_hash, tx_objects=True):
         '''


### PR DESCRIPTION
From the 'needs testing' header, it seems a fairly safe assumption that nobody's using this, but this _is_ a breaking change.
