### PR TITLE
Fixed web3_sha3

### DIFF
--- a/ethjsonrpc/client.py
+++ b/ethjsonrpc/client.py
@@ -138,7 +138,6 @@ class EthJsonRpc(object):
 
         TESTED
         '''
-        data = str(data).encode('hex')
         return self._call('web3_sha3', [data])
 
     def net_version(self):


### PR DESCRIPTION
```
// Request
curl -X POST --data '{"jsonrpc":"2.0","method":"web3_sha3","params":["0x68656c6c6f20776f726c64"],"id":64}'

// Result
{
  "id":64,
  "jsonrpc": "2.0",
  "result": "0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad"
}
```
The data is passed as hex, so we don't need to encode again.