### PR TITLE
Added python 3 support and updated dependencies

### DIFF
--- a/ethjsonrpc/client.py
+++ b/ethjsonrpc/client.py
@@ -3,6 +3,7 @@ import warnings
 
 import requests
 from requests.exceptions import ConnectionError as RequestsConnectionError
+from past.builtins import basestring
 from ethereum import utils
 from ethereum.abi import encode_abi, decode_abi
 

--- a/ethjsonrpc/utils.py
+++ b/ethjsonrpc/utils.py
@@ -1,4 +1,5 @@
 from ethjsonrpc.constants import BLOCK_TAGS
+from past.builtins import basestring
 
 
 def hex_to_dec(x):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ethereum==1.0.8
 requests==2.9.1
+future==0.15.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ethereum==1.0.8
-requests==2.9.1
+ethereum==1.5.2
+requests==2.11.1
 future==0.15.2

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,11 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
     ],
     install_requires=[
         'ethereum==1.0.8',
         'requests==2.9.1',
+        'future==0.15.2',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     install_requires=[
-        'ethereum==1.0.8',
-        'requests==2.9.1',
+        'ethereum==1.5.2',
+        'requests==2.11.1',
         'future==0.15.2',
     ],
 )


### PR DESCRIPTION
Hi! I've added Python 3 support by using `basestring ` from `future` package (the corresponding import is `past.builtins`), now it works both in Python 2 and 3. 

Also I've updated `ethereum ` and `requests` versions in `setup.py` and `requirements.txt`, but it is another commit, so you can merge only Python 3 stuff if you don't want to mess with dependencies.
