### PR TITLE
Add encode_hex helper to ensure hex strings have "0x" prefix

### DIFF
--- a/ethjsonrpc/client.py
+++ b/ethjsonrpc/client.py
@@ -97,7 +97,10 @@ class EthJsonRpc(object):
         if sig is not None and args is not None:
              types = sig[sig.find('(') + 1: sig.find(')')].split(',')
              encoded_params = encode_abi(types, args)
-             code += encode_hex(encoded_params)
+             code += encoded_params.encode('hex')
+        if not code.startswith('0x'):
+            code = '0x' + code
+
         return self.eth_sendTransaction(from_address=from_, gas=gas, data=code)
 
     def get_contract_address(self, tx):

--- a/ethjsonrpc/client.py
+++ b/ethjsonrpc/client.py
@@ -8,7 +8,7 @@ from ethereum import utils
 from ethereum.abi import encode_abi, decode_abi
 
 from ethjsonrpc.constants import BLOCK_TAGS, BLOCK_TAG_LATEST
-from ethjsonrpc.utils import hex_to_dec, clean_hex, validate_block
+from ethjsonrpc.utils import hex_to_dec, clean_hex, validate_block, encode_hex
 from ethjsonrpc.exceptions import (ConnectionError, BadStatusCodeError,
                                    BadJsonError, BadResponseError)
 
@@ -97,7 +97,7 @@ class EthJsonRpc(object):
         if sig is not None and args is not None:
              types = sig[sig.find('(') + 1: sig.find(')')].split(',')
              encoded_params = encode_abi(types, args)
-             code += encoded_params.encode('hex')
+             code += encode_hex(encoded_params)
         return self.eth_sendTransaction(from_address=from_, gas=gas, data=code)
 
     def get_contract_address(self, tx):
@@ -113,7 +113,7 @@ class EthJsonRpc(object):
         transaction (useful for reading data)
         '''
         data = self._encode_function(sig, args)
-        data_hex = data.encode('hex')
+        data_hex = encode_hex(data)
         response = self.eth_call(to_address=address, data=data_hex)
         return decode_abi(result_types, response[2:].decode('hex'))
 
@@ -125,7 +125,7 @@ class EthJsonRpc(object):
         gas = gas or self.DEFAULT_GAS_PER_TX
         gas_price = gas_price or self.DEFAULT_GAS_PRICE
         data = self._encode_function(sig, args)
-        data_hex = data.encode('hex')
+        data_hex = encode_hex(data)
         return self.eth_sendTransaction(from_address=from_, to_address=address, data=data_hex, gas=gas,
                                         gas_price=gas_price, value=value)
 
@@ -147,7 +147,7 @@ class EthJsonRpc(object):
 
         TESTED
         '''
-        data = str(data).encode('hex')
+        data = encode_hex(str(data))
         return self._call('web3_sha3', [data])
 
     def net_version(self):

--- a/ethjsonrpc/utils.py
+++ b/ethjsonrpc/utils.py
@@ -15,6 +15,12 @@ def clean_hex(d):
     '''
     return hex(d).rstrip('L')
 
+def encode_hex(s):
+    '''
+    encode string to hex, adding 0x prefix
+    '''
+    return '0x' + s.encode('hex')
+
 def validate_block(block):
     if isinstance(block, basestring):
         if block not in BLOCK_TAGS:


### PR DESCRIPTION
This adds a `encode_hex` function to utils that just calls `.encode('hex')` on its input and  prepends `0x` to it.  I replaced all the occurrences of `thing.encode('hex')` with it, so geth should accept things now.

Seems to work for me, but I haven't done extensive testing yet.

Closes #26 