### PR TITLE
Add support for personal interface and fix prefix '0x'

### DIFF
--- a/ethjsonrpc/client.py
+++ b/ethjsonrpc/client.py
@@ -714,6 +714,14 @@ class EthJsonRpc(object):
         '''
         return self._call('shh_getMessages', [filter_id])
 
+    def personal_ecRevoer(self, message, signature):
+        '''
+        https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal_ecRecover
+
+        NEEDS TESTED
+        '''
+        return self._call('personal_ecRecover', [message, signature])
+
 
 class ParityEthJsonRpc(EthJsonRpc):
     '''

--- a/ethjsonrpc/client.py
+++ b/ethjsonrpc/client.py
@@ -113,7 +113,7 @@ class EthJsonRpc(object):
         transaction (useful for reading data)
         '''
         data = self._encode_function(sig, args)
-        data_hex = data.encode('hex')
+        data_hex = '0x{0}'.format(data.encode('hex'))
         response = self.eth_call(to_address=address, data=data_hex)
         return decode_abi(result_types, response[2:].decode('hex'))
 


### PR DESCRIPTION
Hi, 

We would like to add support for the `personal` interface of geth. Right now we add `personal.ecRecover`

Also there are little changes with geth 1.6.0. For example a prefix of `0x` is now required. 

Lets discuss it.